### PR TITLE
Allow making OSK optional

### DIFF
--- a/debian/unl0kr.droidian.conf
+++ b/debian/unl0kr.droidian.conf
@@ -4,7 +4,7 @@ backend=minui
 timeout=300
 
 [keyboard]
-autohide=true
+autohide=false
 layout=us
 popovers=true
 

--- a/main.c
+++ b/main.c
@@ -423,11 +423,9 @@ int main(int argc, char *argv[]) {
     ul_indev_set_up_mouse_cursor();
 
     /* Hide the on-screen keyboard by default if a physical keyboard is connected */
-    /*
     if (conf_opts.keyboard.autohide && ul_indev_is_keyboard_connected()) {
         is_keyboard_hidden = true;
     }
-    */
 
     /* Initialise theme */
     set_theme(is_alternate_theme);


### PR DESCRIPTION
Ports (such as Zinwa Q25 with physical keyboard as the focus and wasting a bunch of the 720 vertical pixels isn't ideal) should be able to override this in the initramfs `/etc/unl0kr.conf` via e.g. `sed` in `/scripts/halium-hooks` if nothing else