### PR TITLE
Set altgr-intl us layout variant for typing € with keyd

### DIFF
--- a/lv_drv_conf.h
+++ b/lv_drv_conf.h
@@ -434,7 +434,7 @@
 #    define XKB_KEY_MAP       { .rules = NULL, \
                                 .model = "pc101", \
                                 .layout = "us", \
-                                .variant = NULL, \
+                                .variant = "altgr-intl", \
                                 .options = NULL } /*"setxkbmap -query" can help find the right values for your keyboard*/
 #  endif  /*USE_XKB*/
 #endif  /*USE_LIBINPUT || USE_BSD_LIBINPUT || USE_EVDEV || USE_BSD_EVDEV*/


### PR DESCRIPTION
~~Contains #2 as well for now since this is the branch I built my ramdisk overlay version of `/usr/bin/unl0kr` from.~~

Use `altgr-intl` variant of the `us` layout for typing `€` via [`keyd`](https://github.com/rvaiya/keyd) remappings[0] for physical keyboards during initramfs passphrase unlock isn't really practical otherwise.

Putting this out here for now since it's already working great for my needs, maybe it's even fine as-is

[0] https://gitlab.com/deathmist/halium-gki/-/blob/q25-droidian/ramdisk-overlay/etc/keyd/q25-qwertz